### PR TITLE
Update SLA for label application

### DIFF
--- a/docs/dag/mig-rm.md
+++ b/docs/dag/mig-rm.md
@@ -142,7 +142,7 @@ Policy name and review steps:
 
 * Review your settings and either click publish labels or auto-apply to save your settings depending on the scenario.
 
-* It can take up to 1 day for labels to appear and only for those mailboxes that have 10MB of data or more as noted above in the considerations.
+* It can take up to 7 days for labels to appear and only for those mailboxes that have 10MB of data or more as noted above in the considerations.
 
 #### Start Simple
 


### PR DESCRIPTION
Under "Policy name and review steps:", 3rd bullet should be updated to reflect that it can take up to 7 days for labels to appear. The rest of the statement is correct. 
Confirmed on this Docs page: https://docs.microsoft.com/en-us/microsoft-365/compliance/create-apply-retention-labels?view=o365-worldwide#when-retention-labels-become-available-to-apply